### PR TITLE
Fix processing of the forwarded functions

### DIFF
--- a/Generate_Wrapper.py
+++ b/Generate_Wrapper.py
@@ -59,6 +59,10 @@ for line in lines:
 		if len(line) is 0:
 			break;
 		splt = re.compile("\s*").split(line.strip());
+
+		if len(splt) > 3 and splt[3] == "(forwarded":
+			splt = splt[:-3]
+
 		ordinal = splt[0];
 		fcnname = splt[-1];
 		if fcnname == '[NONAME]':


### PR DESCRIPTION
Hello,

There is an issue with processing forwarded export functions. This is a part of the "dumbin /exports" output:

```
    ordinal hint RVA      name

          1    0          AcquireSRWLockExclusive (forwarded to NTDLL.RtlAcquireSRWLockExclusive)
          2    1          AcquireSRWLockShared (forwarded to NTDLL.RtlAcquireSRWLockShared)
```

Generated assembler code for this case is wrong:

```
.code
extern mProcs:QWORD
NTDLL.RtlAcquireSRWLockExclusive)_wrapper proc
    jmp mProcs[0*8]
NTDLL.RtlAcquireSRWLockExclusive)_wrapper endp
NTDLL.RtlAcquireSRWLockShared)_wrapper proc
    jmp mProcs[1*8]
NTDLL.RtlAcquireSRWLockShared)_wrapper endp
```

My solution is quite straightforward. Probably, you will find a better fix for this. You can reproduce the issue with kernel32.dll system library.

Thank you for useful script!
