### PR TITLE
Fix regex to split symbols

### DIFF
--- a/Generate_Wrapper.py
+++ b/Generate_Wrapper.py
@@ -58,7 +58,7 @@ for line in lines:
 	if start is 2:
 		if len(line) is 0:
 			break;
-		splt = re.compile("\s*").split(line.strip());
+		splt = re.compile("\s+").split(line.strip());
 
 		if len(splt) > 3 and splt[3] == "(forwarded":
 			splt = splt[:-3]


### PR DESCRIPTION
On python 3.7 `re.compile("\s*").split(line.strip());` splits a string into a list of chars, similar to `[char for char in line.strip()]` and python 3.6 gives a [warning](https://stackoverflow.com/questions/47564710/regular-expression-split-futurewarning-split-requires-a-non-empty-pattern-m).